### PR TITLE
config improvements

### DIFF
--- a/boltdbweb.go
+++ b/boltdbweb.go
@@ -75,21 +75,22 @@ func main() {
 		os.Exit(0)
 	}
 
-	fmt.Print(" ")
-	log.Info("starting boltdb-browser..")
-
 	// If non-flag options are included assume bolt db is specified.
-	if dbName == nil && len(args) > 0 {
+	if len(args) > 0 {
 		dbName = args[0]
 	}
 
-	if dbName == nil {
+	if dbName == "" {
 		usage(appName, version)
+		log.Printf("\nERROR: Missing boltdb name\n")
 		os.Exit(1)
 	}
 
+	fmt.Print(" ")
+	log.Info("starting boltdb-browser..")
+
 	var err error
-	db, err = bolt.Open(*dbName, 0600, nil)
+	db, err = bolt.Open(dbName, 0600, nil)
 	boltbrowserweb.Db = db
 
 	if err != nil {
@@ -115,7 +116,7 @@ func main() {
 	r.POST("/deleteBucket", boltbrowserweb.DeleteBucket)
 	r.POST("/prefixScan", boltbrowserweb.PrefixScan)
 
-	r.Static("/web", *staticPath+"/web")
+	r.Static("/web", staticPath+"/web")
 
-	r.Run(":" + *port)
+	r.Run(":" + port)
 }

--- a/boltdbweb.go
+++ b/boltdbweb.go
@@ -1,3 +1,9 @@
+//
+// boltdbweb is a webserver base GUI for interacting with BoltDB databases.
+//
+// For authorship see https://github.com/evnix/boltdbweb
+// MIT license is included in repository
+//
 package main
 
 import (
@@ -9,48 +15,77 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 )
 
+const version = "v0.0.0"
+
 var (
+	showHelp   bool
 	db         *bolt.DB
 	dbName     string
-	port       string 
+	port       string
 	staticPath string
 )
 
+func usage(appName, version string) {
+	fmt.Printf("Usage: %s [OPTIONS] [DB_NAME]", appName)
+	fmt.Printf("\nOPTIONS:\n\n")
+	flag.VisitAll(func(f *flag.Flag) {
+		if len(f.Name) > 1 {
+			fmt.Printf("    -%s, -%s\t%s\n", f.Name[0:1], f.Name, f.Usage)
+		}
+	})
+	fmt.Printf("\n\nVersion %s\n", version)
+}
+
 func init() {
 	// Read the static path from the environment if set.
+	dbName = os.Getenv("BOLTDBWEB_DB_NAME")
+	port = os.Getenv("BOLTDBWEB_PORT")
 	staticPath = os.Getenv("BOLTDBWEB_STATIC_PATH")
+	// Use default values if environment not set.
 	if staticPath == "" {
 		staticPath = "."
 	}
-	dbName = os.Getenv("BOLTDBWEB_DB_NAME")
-	port = os.Getenv("BOLTDBWEB_PORT")
 	if port == "" {
 		port = "8080"
 	}
+	// Setup for command line processing
+	flag.BoolVar(&showHelp, "h", false, "display help")
+	flag.BoolVar(&showHelp, "help", false, "display help")
+	flag.StringVar(&dbName, "d", dbName, "Name of the database")
 	flag.StringVar(&dbName, "db-name", dbName, "Name of the database")
+	flag.StringVar(&port, "p", port, "Port for the web-ui")
 	flag.StringVar(&port, "port", port, "Port for the web-ui")
+	flag.StringVar(&staticPath, "s", staticPath, "Path for the static content")
 	flag.StringVar(&staticPath, "static-path", staticPath, "Path for the static content")
 }
 
 func main() {
+	appName := path.Base(os.Args[0])
 	flag.Parse()
 	args := flag.Args()
 
+	if showHelp == true {
+		usage(appName, version)
+		os.Exit(0)
+	}
+
 	fmt.Print(" ")
 	log.Info("starting boltdb-browser..")
+
+	// If non-flag options are included assume bolt db is specified.
 	if dbName == nil && len(args) > 0 {
 		dbName = args[0]
 	}
 
 	if dbName == nil {
-
-		fmt.Println("Usage: " + os.Args[0] + " --db-name=<DBfilename>[required] --port=<port>[optional] --static-path=<static-path>[optional]")
-		os.Exit(0)
+		usage(appName, version)
+		os.Exit(1)
 	}
 
 	var err error
@@ -58,11 +93,11 @@ func main() {
 	boltbrowserweb.Db = db
 
 	if err != nil {
-
 		fmt.Println(err)
-		os.Exit(0)
+		os.Exit(1)
 	}
 
+	// OK, we should be ready to define/run web server safely.
 	r := gin.Default()
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(200, gin.H{
@@ -83,5 +118,4 @@ func main() {
 	r.Static("/web", *staticPath+"/web")
 
 	r.Run(":" + *port)
-
 }

--- a/boltdbweb.go
+++ b/boltdbweb.go
@@ -16,16 +16,36 @@ import (
 
 var (
 	db         *bolt.DB
-	dbName     = flag.String("db-name", "", "Name of the database")
-	port       = flag.String("port", "8080", "Port for the web-ui")
-	staticPath = flag.String("static-path", ".", "Path for the static content")
+	dbName     string
+	port       string 
+	staticPath string
 )
+
+func init() {
+	// Read the static path from the environment if set.
+	staticPath = os.Getenv("BOLTDBWEB_STATIC_PATH")
+	if staticPath == "" {
+		staticPath = "."
+	}
+	dbName = os.Getenv("BOLTDBWEB_DB_NAME")
+	port = os.Getenv("BOLTDBWEB_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	flag.StringVar(&dbName, "db-name", dbName, "Name of the database")
+	flag.StringVar(&port, "port", port, "Port for the web-ui")
+	flag.StringVar(&staticPath, "static-path", staticPath, "Path for the static content")
+}
 
 func main() {
 	flag.Parse()
+	args := flag.Args()
 
 	fmt.Print(" ")
 	log.Info("starting boltdb-browser..")
+	if dbName == nil && len(args) > 0 {
+		dbName = args[0]
+	}
 
 	if dbName == nil {
 


### PR DESCRIPTION
I've added support to pickup configuration from the environment. 
- BOLTDBWEB_DB_NAME
- BOLTDBWEB_PORT
- BOLTDBWEB_STATIC_PATH

Also added an explicit -help option. Added short args in addition to the long ones. Change os exit codes to 1 if errors happen before the web service starts. 

Finally added a comment at the top of boltdbweb.go file so I could remember where this came from. You probably want to put something else there that makes more sense.

All the best,

Robert.
