### PR TITLE
Doc: remove dollar-space to make cut&paste installation easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ A simple web based boltdb GUI Admin panel.
 
 ##### Installation
 ```
-$ go get github.com/gin-gonic/gin
-$ go get github.com/boltdb/bolt/...
-$ go get github.com/evnix/boltdbweb
-$ cd $GOPATH/src/github.com/evnix/boltdbweb
-$ go build boltdbweb.go
-$ sudo mv boltdbweb /usr/bin (OPTIONAL)
+go get github.com/gin-gonic/gin
+go get github.com/boltdb/bolt/...
+go get github.com/evnix/boltdbweb
+cd $GOPATH/src/github.com/evnix/boltdbweb
+go build boltdbweb.go
+```
+
+Optional
+```
+sudo mv boltdbweb /usr/bin 
 ```
 
 ##### Usage


### PR DESCRIPTION
Hi. I removed the $ to make pasting the installation simpler.